### PR TITLE
Adding SwiftLogFireCloud to table of available backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ As the API has just launched, not many implementations exist yet. If you are int
 | [NSHipster/swift-log-github-actions](https://github.com/NSHipster/swift-log-github-actions) | a logging backend that translates logging messages into [workflow commands for GitHub Actions](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions). |
 | [stevapple/swift-log-telegram](https://github.com/stevapple/swift-log-telegram) | a logging backend that sends log messages to any Telegram chat (Inspired by and forked from [wlisac/swift-log-slack](https://github.com/wlisac/swift-log-slack)) |
 | [jagreenwood/swift-log-datadog](https://github.com/jagreenwood/swift-log-datadog)  | a logging backend which sends log messages to the [Datadog](https://www.datadoghq.com/log-management/) log management service |
+| [google/SwiftLogFireCloud](https://github.com/google/swiftlogfirecloud)  | a logging backend for time series logging which pushes logs as flat files to Firebase Cloud Storage. |
 | Your library? | [Get in touch!](https://forums.swift.org/c/server) |
 
 ## What is an API package?


### PR DESCRIPTION
Adding SwiftLogFireCloud to table of available backends

### Motivation:

Provide visibility to an additional backend available for SwiftLog

### Modifications:

Added row to list of impls in readme.MD

### Result:

Table of community SwiftLog impls.
